### PR TITLE
Enumerable list entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ if root.has?(:all_products)
     puts product.price
   end
 
-  # Iterate through pages or products
+  # Iterate through pages of products
   # See "iterating" section below for a more elegant option
   if all_products.has?(:next)
     next_page = all_products.next

--- a/README.md
+++ b/README.md
@@ -52,11 +52,39 @@ if root.has?(:all_products)
     puts product.price
   end
 
-  if all_product.has?(:next)
+  # Iterate through pages or products
+  # See "iterating" section below for a more elegant option
+  if all_products.has?(:next)
     next_page = all_products.next
     next_page.each{...}
   end
 end
+```
+
+### Iterating
+
+Entities representing lists of things ([products](https://developers.bootic.net/rels/products/), [orders](https://developers.bootic.net/rels/orders/), etc) are fully [enumerable](http://ruby-doc.org/core-2.2.0/Enumerable.html).
+
+```ruby
+# These will only iterate this page's worth of products
+all_products.each{|pr| puts pr.title}
+all_products.map(&:title)
+all_products.reduce(0){|sum, pr| sum + pr.price}
+```
+
+These lists might be part of a paginated data set. If you want to iterate items across pages and make sure you consume the full set, use `#full_set`.
+
+```ruby
+# These will iterate all necessary pages
+all_products.full_set.each{|pr| puts pr.title }
+all_products.full_set.map(&:title)
+all_products.full_set.first(500)
+```
+
+You can check whether an entity is iterable with:
+
+```ruby
+all_products.respond_to?(:each)
 ```
 
 ## Strategies

--- a/lib/bootic_client/entity.rb
+++ b/lib/bootic_client/entity.rb
@@ -8,6 +8,18 @@ module BooticClient
     def each(&block)
       self[:items].each &block
     end
+
+    def full_set
+      page = self
+
+      Enumerator.new do |yielder|
+        loop do
+          page.each{|item| yielder.yield item }
+          raise StopIteration unless page.has_rel?(:next)
+          page = page.next
+        end
+      end
+    end
   end
 
   class Entity

--- a/lib/bootic_client/entity.rb
+++ b/lib/bootic_client/entity.rb
@@ -2,7 +2,7 @@ require "bootic_client/relation"
 require 'ostruct'
 
 module BooticClient
-  module IterableEntity
+  module EnumerableEntity
     include Enumerable
 
     def each(&block)
@@ -33,7 +33,7 @@ module BooticClient
     def initialize(attrs, client, top = self)
       @attrs, @client, @top = attrs, client, top
       build!
-      self.extend IterableEntity if iterable?
+      self.extend EnumerableEntity if iterable?
     end
 
     def to_hash

--- a/lib/bootic_client/entity.rb
+++ b/lib/bootic_client/entity.rb
@@ -2,6 +2,14 @@ require "bootic_client/relation"
 require 'ostruct'
 
 module BooticClient
+  module IterableEntity
+    include Enumerable
+
+    def each(&block)
+      self[:items].each &block
+    end
+  end
+
   class Entity
 
     CURIE_EXP = /(.+):(.+)/.freeze
@@ -13,6 +21,7 @@ module BooticClient
     def initialize(attrs, client, top = self)
       @attrs, @client, @top = attrs, client, top
       build!
+      self.extend IterableEntity if iterable?
     end
 
     def to_hash
@@ -86,10 +95,6 @@ module BooticClient
 
     def has_rel?(prop_name)
       rels.has_key? prop_name.to_sym
-    end
-
-    def each(&block)
-      iterable? ? entities[:items].each(&block) : [self].each(&block)
     end
 
     def rels

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -172,17 +172,18 @@ describe BooticClient::Entity do
     end
 
     describe 'iterating' do
-      it 'iterates items if it is a list' do
+      it 'is an anumerable if it is a list' do
         prods = []
         entity.each{|pr| prods << pr}
         expect(prods).to match_array(entity.items)
+        expect(entity.map{|pr| pr}).to match_array(entity.items)
+        expect(entity.reduce(0){|sum,e| sum + e.price.to_i}).to eql(24687)
+        expect(entity.each).to be_kind_of(Enumerator)
       end
 
-      it 'iterates itself if not a list' do
+      it 'is not treated as an array if not a list' do
         ent = BooticClient::Entity.new({'foo' => 'bar'}, client)
-        ents = []
-        ent.each{|e| ents << e}
-        expect(ents).to match_array([ent])
+        expect(ent).not_to respond_to(:each)
       end
     end
   end

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -172,7 +172,7 @@ describe BooticClient::Entity do
     end
 
     describe 'iterating' do
-      it 'is an anumerable if it is a list' do
+      it 'is an enumerable if it is a list' do
         prods = []
         entity.each{|pr| prods << pr}
         expect(prods).to match_array(entity.items)
@@ -207,9 +207,6 @@ describe BooticClient::Entity do
         }
       }
       let(:page_2) { BooticClient::Entity.new(page_2_data, client) }
-
-      before do
-      end
 
       it 'lazily enumerates entries across pages, making as little requests as possible' do
         expect(client).to receive(:request_and_wrap).with(:get, '/foo?page=2', BooticClient::Entity, {}).and_return page_2


### PR DESCRIPTION
## What

Make result entities representing _lists_ fully `Enumerable`. See new "Iterating" section in Readme for details.

The new `Entity#full_set` method returns a Ruby Enumerator that will walk across page requests to yield the necessary items.

``` ruby
products = root.all_products
# This iterates products in the current page
products.each {|pr| ...}

# #each returns an Enumerator
products.each.with_index{|pr, index| ...}

# #full_set iterates across pages
products.full_set.each{|pr| ...}

# It will make as little requests as possible to satisfy the enumeration
# For 50 items per page, the following will only request pages 2 and 3 (page 1 is already loaded).
products.full_set.first(120).map{|pr| pr.title}
```
