### PR TITLE
Basic auth strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ client = BooticClient.client(:client_credentials, scope: 'admin', access_token: 
 end
 ```
 
+### 3. Basic Auth
+
+This strategy uses a `username` and `password` against APIs supporting HTTP's Basic Authentication scheme.
+
+The official Bootic API only supports OAuth2 tokens, but this allows the client to be used against internal APIs or stub APIs on development.
+
+```ruby
+client = BooticClient.client(:basic_auth, username: 'foo', password: 'bar')
+
+root = client.root # etc
+```
+
+NOTE: `username` and `password` have nothing to do with your Bootic administrative credentials, and will be up to API maintainers to define.
+
 ## Non GET links
 
 Most resource links lead to `GET` resources, but some will expect `POST`, `PUT`, `DELETE` or others.

--- a/lib/bootic_client/strategies/basic_auth.rb
+++ b/lib/bootic_client/strategies/basic_auth.rb
@@ -1,0 +1,27 @@
+require 'bootic_client/strategies/strategy'
+
+module BooticClient
+  module Strategies
+    class BasicAuth < Strategy
+
+      def inspect
+        %(#<#{self.class.name} root: #{config.api_root} username: #{options[:username]}>)
+      end
+
+      protected
+
+      def validate!
+        raise ArgumentError, "options MUST include username" unless options[:username]
+        raise ArgumentError, "options MUST include password" unless options[:password]
+      end
+
+      def client
+        @client ||= Client.new(options) do |c|
+          c.request :basic_auth, options[:username], options[:password]
+        end
+      end
+    end
+  end
+
+  strategies[:basic_auth] = Strategies::BasicAuth
+end

--- a/spec/basic_auth_strategy_spec.rb
+++ b/spec/basic_auth_strategy_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe 'BooticClient::Strategies::BasicAuth' do
+  require 'webmock/rspec'
+
+  let(:root_data) {
+    {
+      '_links' => {
+        'a_product' => {'href' => 'https://api.bootic.net/v1/products/1'}
+      },
+      'message' => "Hello!"
+    }
+  }
+
+  let(:product_data) {
+    {'title' => 'iPhone 6 Plus'}
+  }
+
+  let(:client) { BooticClient.client(:basic_auth, username: 'foo', password: 'bar') }
+
+  describe '#inspect' do
+    it 'is informative' do
+      expect(client.inspect).to eql %(#<BooticClient::Strategies::BasicAuth root: https://api.bootic.net/v1 username: foo>)
+    end
+  end
+  context 'with missing credentials' do
+    it 'raises error' do
+      expect{
+        BooticClient.client(:basic_auth)
+      }.to raise_error
+    end
+  end
+
+  context 'with invalid BasicAuth credentials' do
+    let!(:root_request) do
+      stub_request(:get, 'https://foo:bar@api.bootic.net/v1')
+        .to_return(status: 401, body: JSON.dump(root_data))
+    end
+
+    it 'raises an Unauthorized error' do
+      expect{ client.root }.to raise_error(BooticClient::UnauthorizedError)
+      expect(root_request).to have_been_requested
+    end
+  end
+
+  context 'with valid BasicAuth credentials' do
+    let!(:root_request) do
+      stub_request(:get, 'https://foo:bar@api.bootic.net/v1')
+        .to_return(status: 200, body: JSON.dump(root_data))
+    end
+
+    let!(:product_request) do
+      stub_request(:get, 'https://foo:bar@api.bootic.net/v1/products/1')
+        .to_return(status: 200, body: JSON.dump(product_data))
+    end
+
+    let!(:root) { client.root }
+
+    it 'includes Basic Auth credentials in request' do
+      expect(root_request).to have_been_requested
+      expect(root.message).to eql('Hello!')
+    end
+
+    it 'follows links as normal, including Basic Auth in every request' do
+      product = root.a_product
+      expect(product_request).to have_been_requested
+      expect(product.title).to eql 'iPhone 6 Plus'
+    end
+  end
+end

--- a/spec/basic_auth_strategy_spec.rb
+++ b/spec/basic_auth_strategy_spec.rb
@@ -23,11 +23,12 @@ describe 'BooticClient::Strategies::BasicAuth' do
       expect(client.inspect).to eql %(#<BooticClient::Strategies::BasicAuth root: https://api.bootic.net/v1 username: foo>)
     end
   end
+
   context 'with missing credentials' do
     it 'raises error' do
       expect{
         BooticClient.client(:basic_auth)
-      }.to raise_error
+      }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
## What

Implement HTTP Basic Authentication strategy so the BooticClient can be used with APIs supporting that authentication method.
## Why

So we can use the same client library for Bootic's public API and internal services that do not support OAuth2. This makes it easier to swap backend services with little impact on client code.
## Example

Instantiate a client using `:basic_auth`

``` ruby
client = BooticClient.client(:basic_auth, username: 'foo', password: 'bar')
```

Optionally define a custom root resource with available links.

``` ruby
api = client.from_hash(
  _links: {
    post_message: {href: 'https://some.api.com/messages', method: 'post'},
    add_to_cart: {href: 'https://some.api.com/cart/:id', method: 'post', templated: true}
  }
)
```

Now you can use your custom API with Basic Auth

``` ruby
message = api.post_message(title: 'A new message', name: 'John Doe')
# POST https://foo:bar@some.api.com/messages

cart_item = api.add_to_cart(id: 'R12DF3', variant_id: 123, units: 2)
# POST https://foo:bar@some.api.com/cart/R12DF3
```
