### PR TITLE
Relation#parameters lists available parameter names for templated URLs.

### DIFF
--- a/lib/bootic_client/relation.rb
+++ b/lib/bootic_client/relation.rb
@@ -23,6 +23,10 @@ module BooticClient
       !!attrs['templated']
     end
 
+    def parameters
+      @parameters ||= templated? ? uri.variables : []
+    end
+
     def name
       attrs['name']
     end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -29,6 +29,10 @@ describe BooticClient::Relation do
           expect(relation.templated?).to eql(false)
         end
 
+        it 'does not have parameters' do
+          expect(relation.parameters).to eql []
+        end
+
         it 'passes query string to client' do
           expect(client).to receive(:request_and_wrap).with(:get, '/foos/bar', BooticClient::Entity, id: 2, q: 'test', page: 2).and_return entity
           expect(relation.run(id: 2, q: 'test', page: 2)).to eql(entity)
@@ -45,6 +49,10 @@ describe BooticClient::Relation do
         it 'works with defaults' do
           expect(client).to receive(:request_and_wrap).with(:get, '/foos/', BooticClient::Entity, {}).and_return entity
           expect(relation.run).to eql(entity)
+        end
+
+        it 'has parameter list' do
+          expect(relation.parameters).to eql ['id', 'q', 'page']
         end
 
         it 'interpolates tokens' do


### PR DESCRIPTION
## What

`Relation#parameters` returns an array of available URL parameters for a _templated_ URL.
### Example

``` ruby
root = client.root

root.rels[:all_products].parameters

# https://developers.bootic.net/rels/products/

# returns:

[
"q", 
"page", 
"per_page", 
"status", 
"shop_subdomains", 
"collections", 
"shop_ids", 
"type_ids",
"tags", 
"global_tags", 
"variants", 
"sku", 
"currency", 
"price.gte", 
"price.lte", 
"discount_percentage.gte", 
"discount_percentage.lte", 
"created_on.gte", 
"created_on.lte", 
"updated_on.gte", 
"updated_on.lte", 
"account_status", 
"account_plan", 
"sort", 
"facets"]
```
## Why

So it’s easier to inspect what parameters are available for each URL, and to programatically list those options in other programs.
