### PR TITLE
Faraday http cache 1.2.2, Vary header support.

### DIFF
--- a/bootic_client.gemspec
+++ b/bootic_client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", '~> 0.9'
   spec.add_dependency "uri_template", '~> 0.7'
   spec.add_dependency "faraday_middleware", '~> 0.9'
-  spec.add_dependency "faraday-http-cache", '0.4.2'
+  spec.add_dependency "faraday-http-cache", '1.2.2'
   spec.add_dependency "net-http-persistent", '~> 2.9'
   spec.add_dependency "oauth2", "~> 1"
 


### PR DESCRIPTION
## What
- Upgrade to [faraday_http_cache](https://github.com/plataformatec/faraday-http-cache) version 1.2.2.
- test `Vary` header support.
## Why

The latest faraday-http-cache comes with the following useful features:
### Vary header support

Useful because we can cache different versions of the same resource (ie. `/v1`) for different users. The API can include `Vary: Accept-Encoding,Authorization` in its responses, thus making the access token part of the cache-key. This means that endpoints that don't change often for each user can be cached for longer times using `Cache-Control`.
### Delete cached resources on PUT, DELETE, POST.

The client will now auto-expire a resource after using these verbs, so the next GET is fresh.

.. And [a bunch](https://github.com/plataformatec/faraday-http-cache/blob/master/CHANGELOG.md) or other improvements.

All of these are transparent to this library. The caching improvements will _just work_ when the API sends the right headers.
