### PR TITLE
Faraday HTTP Cache expects memcache store must respond to #delete

### DIFF
--- a/lib/bootic_client/stores/memcache.rb
+++ b/lib/bootic_client/stores/memcache.rb
@@ -21,6 +21,10 @@ module BooticClient
         @client.get key
       end
 
+      def delete(key)
+        @client.delete key
+      end
+
       def set(key, data, ttl = nil)
         @client.set key, data, ttl
       end

--- a/spec/memcache_storage_spec.rb
+++ b/spec/memcache_storage_spec.rb
@@ -23,6 +23,13 @@ describe BooticClient::Stores::Memcache do
     end
   end
 
+  shared_examples_for 'dalli :delete' do |method_name|
+    it 'delegates to Dalli client #delete' do
+      expect(dalli).to receive(:delete).with('foo').and_return true
+      expect(store.send(method_name, 'foo')).to be true
+    end
+  end
+
   describe '#initialize' do
     it 'creates a Dalli instance' do
       expect(Dalli::Client).to receive(:new).with(['localhost:1112'], foo: 'bar').and_return dalli
@@ -44,6 +51,10 @@ describe BooticClient::Stores::Memcache do
 
   describe '#set' do
     it_behaves_like 'dalli :set', :set
+  end
+
+  describe '#delete' do
+    it_behaves_like 'dalli :delete', :delete
   end
 
   describe '#stats' do


### PR DESCRIPTION
The new version of faraday-http-cache expects the memcache cache store to respond to `#delete(key)`.

This was missing from that gem's documentation.
