### PR TITLE
Base64-encode any attribute that responds to #read

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,38 @@ end
 
 ### Working with Files and IO instances
 
-Instances of `File` and other readable `IO` objects will be base64-encoded internally before JSON-encoding payloads for `POST`, `PUT` and `PATCH` requests.
+Instances of `File`, other readable `IO` objects (and in fact anything that responds to `#read`) will be base64-encoded internally before JSON-encoding payloads for `POST`, `PUT` and `PATCH` requests.
 
 ```ruby
 asset = product.create_product_asset(
   filename: 'foo.jpg',
   data: File.new('/path/to/foo.jpg') # this will base64-encode the file data in the `data` field.
+)
+```
+
+Because anything that responds to `#read` will be interpreted as file data and base64-encoded, you can also pass instances of `open-uri`.
+
+```ruby
+require "open-uri"
+
+asset = product.create_product_asset(
+  filename: 'foo.jpg',
+  data: open("https://some.server.com/some/image.jpg") # this will base64-encode the file data in the `data` field.
+)
+```
+
+.. or even your own readers
+
+```ruby
+class MyReader
+  def read
+    "some data here"
+  end
+end
+
+asset = product.create_product_asset(
+  filename: 'foo.jpg',
+  data: MyReader.new # this will base64-encode the file data in the `data` field.
 )
 ```
 

--- a/lib/bootic_client/client.rb
+++ b/lib/bootic_client/client.rb
@@ -103,11 +103,10 @@ module BooticClient
     def sanitized(payload)
       return payload unless payload.kind_of?(Hash)
       payload.each_with_object({}) do |(k, v), memo|
-        memo[k] = case v
-        when IO
-          Base64.encode64 v.read
-        when Hash
+        memo[k] = if v.kind_of?(Hash)
           sanitized v
+        elsif v.respond_to?(:read)
+          Base64.encode64 v.read
         else
           v
         end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'json'
+require "open-uri"
 
 describe BooticClient::Client do
   require 'webmock/rspec'
@@ -203,6 +204,16 @@ describe BooticClient::Client do
 
         it 'POSTs request with base64-encoded file and parses response' do
           expect(client.post(root_url, {foo: 'bar', data: file}, request_headers).body['message']).to eql('Hello!')
+        end
+
+        it "works with anything that responds to #read" do
+          reader = double("reader", read: File.read(fixture_path("file.gif")))
+          expect(client.post(root_url, {foo: 'bar', data: reader}, request_headers).body['message']).to eql('Hello!')
+        end
+
+        it "works with open-uri" do
+          reader = open(fixture_path("file.gif"))
+          expect(client.post(root_url, {foo: 'bar', data: reader}, request_headers).body['message']).to eql('Hello!')
         end
       end
 


### PR DESCRIPTION
## What

When updating entity attributes, any instances of `File`, other readable `IO` objects (and in fact anything that responds to `#read`) will be base64-encoded internally before JSON-encoding payloads for `POST`, `PUT` and `PATCH` requests.

## Why

So it's easy to work with files (ie. when uploading file assets from disk or other sources, including HTTP).

```ruby
asset = product.create_product_asset(
  filename: 'foo.jpg',
  data: File.new('/path/to/foo.jpg') # this will base64-encode the file data in the `data` field.
)
```

Because anything that responds to `#read` will be interpreted as file data and base64-encoded, you can also pass instances of `open-uri`.

```ruby
require "open-uri"

asset = product.create_product_asset(
  filename: 'foo.jpg',
  data: open("https://some.server.com/some/image.jpg") # this will base64-encode the file data in the `data` field.
)
```

.. or even your own readers

```ruby
class MyReader
  def read
    "some data here"
  end
end

asset = product.create_product_asset(
  filename: 'foo.jpg',
  data: MyReader.new # this will base64-encode the file data in the `data` field.
)
```
