### PR TITLE
Client#from_url(url)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ new_message = messaging_api.send_message(title: 'This is a new message')
 messaging_api.delete_message(id: new_message.id)
 ```
 
+It's also possibe to load a root resource directly from a URL:
+
+```ruby
+messaging_api_root = client.from_url("https://some.api.com")
+messaging_api.do_something(foo: "bar") # etc
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/bootic_client/strategies/strategy.rb
+++ b/lib/bootic_client/strategies/strategy.rb
@@ -17,6 +17,10 @@ module BooticClient
         wrapper_class.new hash, self
       end
 
+      def from_url(url, wrapper_class = Entity)
+        request_and_wrap :get, url, wrapper_class
+      end
+
       def request_and_wrap(request_method, href, wrapper_class, payload = {})
         pre_flight
         retryable do

--- a/spec/authorized_strategy_spec.rb
+++ b/spec/authorized_strategy_spec.rb
@@ -153,5 +153,16 @@ describe 'BooticClient::Strategies::Authorized' do
         expect(entity.can?(:delete)).to be true
       end
     end
+
+    describe '#from_url' do
+      it 'builds and returns an entity' do
+        authorized_request = stub_request(:get, "https://api.bootic.net/v1/shops").
+          to_return(status: 200, :body => JSON.dump(title: 'All shops'))
+
+        entity = client.from_url('https://api.bootic.net/v1/shops')
+        expect(entity).to be_kind_of(BooticClient::Entity)
+        expect(entity.title).to eql('All shops')
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Add convenience method `Client#from_url(uri)` to load a root resource from a URL.

## Why

Super useful for trying out a configured client instance against custom endpoint URLs.

```ruby
messaging_api_root = client.from_url("https://some.api.com")
messaging_api.do_something(foo: "bar") # etc
```