### PR TITLE
Bearer token strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ root = client.root # etc
 
 NOTE: `username` and `password` have nothing to do with your Bootic administrative credentials, and will be up to API maintainers to define.
 
+### 4. Bearer token
+
+This strategy adds an access token as a header in the format `Authorization: Bearer <your-token-here>`.
+It will not try to refresh an expired token from an Oauth2 server, so there's no need to configure Oauth2 credentials.
+
+Use this with APIs that don't expire tokens, or for testing.
+
 ## Non GET links
 
 Most resource links lead to `GET` resources, but some will expect `POST`, `PUT`, `DELETE` or others.

--- a/lib/bootic_client/strategies/bearer.rb
+++ b/lib/bootic_client/strategies/bearer.rb
@@ -1,0 +1,22 @@
+require 'bootic_client/strategies/strategy'
+
+module BooticClient
+  module Strategies
+    class Bearer < Strategy
+
+      private
+
+      def validate!
+        raise ArgumentError, "options MUST include access_token" unless options[:access_token]
+      end
+
+      def request_headers
+        {
+          'Authorization' => "Bearer #{options[:access_token]}"
+        }
+      end
+    end
+  end
+
+  strategies[:bearer] = Strategies::Bearer
+end

--- a/spec/bearer_strategy_spec.rb
+++ b/spec/bearer_strategy_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe 'BooticClient::Strategies::Bearer' do
+  require 'webmock/rspec'
+
+  let(:root_data) {
+    {
+      '_links' => {
+        'a_product' => {'href' => 'https://api.bootic.net/v1/products/1'}
+      },
+      'message' => "Hello!"
+    }
+  }
+
+  let(:product_data) {
+    {'title' => 'iPhone 6 Plus'}
+  }
+
+  let(:client) { BooticClient.client(:bearer, access_token: 'foobar') }
+
+  describe '#inspect' do
+    it 'is informative' do
+      expect(client.inspect).to eql %(#<BooticClient::Strategies::Bearer root: https://api.bootic.net/v1>)
+    end
+  end
+
+  context 'with missing access token' do
+    it 'raises error' do
+      expect{
+        BooticClient.client(:bearer)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'with invalid access token' do
+    let!(:root_request) do
+      stub_request(:get, 'https://api.bootic.net/v1')
+        .with(headers: {"Authorization" => "Bearer foobar"})
+        .to_return(status: 401, body: JSON.dump(root_data))
+    end
+
+    it 'raises an Unauthorized error' do
+      expect{ client.root }.to raise_error(BooticClient::UnauthorizedError)
+      expect(root_request).to have_been_requested
+    end
+  end
+
+  context 'with valid access token' do
+    let!(:root_request) do
+      stub_request(:get, 'https://api.bootic.net/v1')
+        .with(headers: {"Authorization" => "Bearer foobar"})
+        .to_return(status: 200, body: JSON.dump(root_data))
+    end
+
+    let!(:product_request) do
+      stub_request(:get, 'https://api.bootic.net/v1/products/1')
+        .with(headers: {"Authorization" => "Bearer foobar"})
+        .to_return(status: 200, body: JSON.dump(product_data))
+    end
+
+    let!(:root) { client.root }
+
+    it 'includes Basic Auth credentials in request' do
+      expect(root_request).to have_been_requested
+      expect(root.message).to eql('Hello!')
+    end
+
+    it 'follows links as normal, including bearer token in every request' do
+      product = root.a_product
+      expect(product_request).to have_been_requested
+      expect(product.title).to eql 'iPhone 6 Plus'
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a _bearer token_ auth strategy.

```ruby
client = BooticClient.client(:bearer, access_token: "some-token")

root = client.root # etc
```

This strategy adds an access token as a header in the format:

`Authorization: Bearer <your-token-here>`

It will not try to refresh an expired token from an Oauth2 server, so there's no need to configure Oauth2 credentials.

Use this with APIs that don't expire tokens, or for testing.
