### PR TITLE
Raise errors on invalid URLs

### DIFF
--- a/lib/bootic_client/errors.rb
+++ b/lib/bootic_client/errors.rb
@@ -5,4 +5,6 @@ module BooticClient
   class AuthorizationError < ServerError; end
   class UnauthorizedError < AuthorizationError; end
   class AccessForbiddenError < AuthorizationError; end
+  class ClientError < TransportError; end
+  class InvalidURLError < ClientError; end
 end

--- a/lib/bootic_client/whiny_uri.rb
+++ b/lib/bootic_client/whiny_uri.rb
@@ -1,0 +1,62 @@
+require 'uri_template'
+
+module BooticClient
+  class WhinyURI
+    attr_reader :variables
+
+    def initialize(href)
+      @href = href
+      @uri = URITemplate.new(href)
+      @variables = @uri.variables
+    end
+
+    def expand(attrs = {})
+      missing = missing_path_variables(attrs)
+      if missing.any?
+        raise InvalidURLError, missing_err(missing)
+      end
+
+      undeclared = undeclared_params(attrs)
+      if undeclared.any?
+        raise InvalidURLError, undeclared_err(undeclared)
+      end
+
+      uri.expand attrs
+    end
+
+    private
+    attr_reader :uri, :href
+
+    def path_variables
+      @path_variables ||= (
+        variables.find_all{ |v|
+          Regexp.new("(\/\{#{v}\})|(\{\/#{v}\})") =~ href
+        }
+      )
+    end
+
+    def missing_path_variables(attrs)
+      path_variables - attrs.keys.map(&:to_s)
+    end
+
+    def undeclared_params(attrs)
+      attrs.keys.map(&:to_s) - variables
+    end
+
+    def undeclared_err(undeclared)
+      msg = ["undeclared URI variables: #{format_vars(undeclared)}"]
+      query_vars = variables - path_variables
+      msg << "Allowed query variables are #{format_vars(query_vars)}" if query_vars.any?
+      msg.join('. ')
+    end
+
+    def missing_err(missing)
+      "missing required path variables: #{format_vars(missing)}"
+    end
+
+    def format_vars(vars)
+      vars.map{|v| "`#{v}`"}.join(', ')
+    end
+  end
+end
+

--- a/spec/whiny_uri_spec.rb
+++ b/spec/whiny_uri_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+require 'uri_template'
+module BooticClient
+  class WhinyURI
+    attr_reader :variables
+
+    def initialize(href)
+      @href = href
+      @uri = URITemplate.new(href)
+      @variables = @uri.variables
+    end
+
+    def expand(attrs = {})
+      missing = missing_path_variables(attrs)
+      if missing.any?
+        raise InvalidURLError, "missing: #{missing.join(', ')}"
+      end
+
+      undeclared = undeclared_params(attrs)
+      if undeclared.any?
+        raise InvalidURLError, "undeclared: #{undeclared.join(', ')}"
+      end
+
+      uri.expand attrs
+    end
+
+    private
+    attr_reader :uri, :href
+
+    def path_variables
+      @path_variables ||= (
+        variables.find_all{ |v|
+          Regexp.new("(\/\{#{v}\})|(\{\/#{v}\})") =~ href
+        }
+      )
+    end
+
+    def missing_path_variables(attrs)
+      path_variables - attrs.keys.map(&:to_s)
+    end
+
+    def undeclared_params(attrs)
+      attrs.keys.map(&:to_s) - variables
+    end
+  end
+end
+
+describe BooticClient::WhinyURI do
+  describe '#expand' do
+    let(:uri) {
+      described_class.new('http://www.host.com/shops/{id}/{?foo}')
+    }
+
+    it 'complains if missing a path segment' do
+      expect{
+        uri.expand(foo: 1)
+      }.to raise_error BooticClient::InvalidURLError
+    end
+
+    it 'expands if all path variables provided' do
+      expect(uri.expand(id: 123))
+        .to eql 'http://www.host.com/shops/123/'
+    end
+
+    it 'complains if passing undeclared params' do
+      expect{
+        uri.expand(id: 123, nope: 'nope')
+      }.to raise_error BooticClient::InvalidURLError
+    end
+
+    it 'expands if passing declared query variables' do
+      expect(uri.expand(id: 123, foo: 'yes'))
+        .to eql 'http://www.host.com/shops/123/?foo=yes'
+    end
+  end
+end

--- a/spec/whiny_uri_spec.rb
+++ b/spec/whiny_uri_spec.rb
@@ -13,6 +13,13 @@ describe BooticClient::WhinyURI do
       }.to raise_error BooticClient::InvalidURLError
     end
 
+    it 'understand different path segment syntax' do
+      uri = described_class.new('http://www.host.com/shops{/id}/{?foo}')
+      expect{
+        uri.expand(foo: 1)
+      }.to raise_error BooticClient::InvalidURLError
+    end
+
     it 'expands if all path variables provided' do
       expect(uri.expand(id: 123))
         .to eql 'http://www.host.com/shops/123/'
@@ -24,9 +31,22 @@ describe BooticClient::WhinyURI do
       }.to raise_error BooticClient::InvalidURLError
     end
 
+    it 'understand variable lists in query' do
+      uri = described_class.new('http://www.host.com/shops{/id}/{?foo,bar}')
+      expect{
+        uri.expand(id: 123, foo: 'foo', bar: 'bar', nope: 'nope')
+      }.to raise_error BooticClient::InvalidURLError
+    end
+
     it 'expands if passing declared query variables' do
       expect(uri.expand(id: 123, foo: 'yes'))
         .to eql 'http://www.host.com/shops/123/?foo=yes'
+    end
+
+    it 'expands if passing declared query variables defined as list' do
+      uri = described_class.new('http://www.host.com/shops{/id}/{?foo,bar}')
+      expect(uri.expand(id: 123, foo: 'yes', bar: 'no'))
+        .to eql 'http://www.host.com/shops/123/?foo=yes&bar=no'
     end
   end
 end

--- a/spec/whiny_uri_spec.rb
+++ b/spec/whiny_uri_spec.rb
@@ -1,50 +1,5 @@
 require 'spec_helper'
-
-require 'uri_template'
-module BooticClient
-  class WhinyURI
-    attr_reader :variables
-
-    def initialize(href)
-      @href = href
-      @uri = URITemplate.new(href)
-      @variables = @uri.variables
-    end
-
-    def expand(attrs = {})
-      missing = missing_path_variables(attrs)
-      if missing.any?
-        raise InvalidURLError, "missing: #{missing.join(', ')}"
-      end
-
-      undeclared = undeclared_params(attrs)
-      if undeclared.any?
-        raise InvalidURLError, "undeclared: #{undeclared.join(', ')}"
-      end
-
-      uri.expand attrs
-    end
-
-    private
-    attr_reader :uri, :href
-
-    def path_variables
-      @path_variables ||= (
-        variables.find_all{ |v|
-          Regexp.new("(\/\{#{v}\})|(\{\/#{v}\})") =~ href
-        }
-      )
-    end
-
-    def missing_path_variables(attrs)
-      path_variables - attrs.keys.map(&:to_s)
-    end
-
-    def undeclared_params(attrs)
-      attrs.keys.map(&:to_s) - variables
-    end
-  end
-end
+require "bootic_client/whiny_uri"
 
 describe BooticClient::WhinyURI do
   describe '#expand' do


### PR DESCRIPTION
## What

Make templated links raise useful exception when:

* Missing path variables. ex. `/shops/{id}` will fail if `id` param is not passed.
* Passing undeclared _query_ params. ex. `/shops{?q,page}` will fail if passing `foo`

## Why

**Before:** calling `/shops/{id}` without `id` would make a request to `/shops`, which is unexpected.
**Now:** calling `/shops/{id}` without `id` will raise a `InvalidURLError` with a useful error message saying that the `id` param is required.

**Before:** calling `/shops{?subdomains}` with misspelled `subdomain` would make a request to `/shops`, without any filters.
**Now:** calling `/shops{?subdomains}` with _any_ unknown param will raise an `InvalidURLError` with a useful error listing unexpected and allowed params.

## Example

```ruby
# complains if passing unknown query params
shops = root.all_shops(subdomain: "nope")
BooticClient::InvalidURLError:
   undeclared URI variables: `subdomain`. Allowed query variables are `subdomains`, `page`, `per_page`, `q`

# complains if missing required path param
shop = root.shop(subdomains: "nope")
BooticClient::InvalidURLError:
   missing required path variables: `id`
```

## Notes

Unexpected query variables are only validated on non-destructive actions (GET, OPTIONS, HEAD). This is because POST, PATCH and PUT assume that remaining variables are part of the request _body_.

## How

The [URI Template](https://tools.ietf.org/html/rfc6570) specification doesn't seem to support _required_ path parameters (the libraries I tried just omit them silently). So this PR introduces a `WhinyURI` class that wraps `URITemplate` to provide these validations.
