### PR TITLE
Whitelist undeclared params

### DIFF
--- a/lib/bootic_client/entity.rb
+++ b/lib/bootic_client/entity.rb
@@ -30,7 +30,7 @@ module BooticClient
 
     attr_reader :curies, :entities
 
-    def initialize(attrs, client, top = self)
+    def initialize(attrs, client, top: self)
       @attrs = attrs.kind_of?(Hash) ? attrs : {}
       @client, @top = client, top
       build!
@@ -142,9 +142,9 @@ module BooticClient
 
       @entities = attrs.fetch('_embedded', {}).each_with_object({}) do |(k,v),memo|
         memo[k.to_sym] = if v.kind_of?(Array)
-          v.map{|ent_attrs| Entity.new(ent_attrs, client, top)}
+          v.map{|ent_attrs| Entity.new(ent_attrs, client, top: top)}
         else
-          Entity.new(v, client, top)
+          Entity.new(v, client, top: top)
         end
       end
     end

--- a/lib/bootic_client/entity.rb
+++ b/lib/bootic_client/entity.rb
@@ -123,7 +123,7 @@ module BooticClient
           end
           if rel != CURIES_REL
             rel_attrs['name'] = rel
-            memo[rel.to_sym] = Relation.new(rel_attrs, client, Entity)
+            memo[rel.to_sym] = Relation.new(rel_attrs, client, entity_class: Entity)
           end
         end
       )

--- a/lib/bootic_client/entity.rb
+++ b/lib/bootic_client/entity.rb
@@ -27,14 +27,12 @@ module BooticClient
     CURIE_EXP = /(.+):(.+)/.freeze
     CURIES_REL = 'curies'.freeze
     SPECIAL_PROP_EXP = /^_.+/.freeze
-    DEFAULT_CONFIG = OpenStruct.new(complain_on_undeclared_params: true).freeze
 
     attr_reader :curies, :entities
 
-    def initialize(attrs, client, top: self, config: DEFAULT_CONFIG)
+    def initialize(attrs, client, top: self)
       @attrs = attrs.kind_of?(Hash) ? attrs : {}
       @client, @top = client, top
-      @config = config
       build!
       self.extend EnumerableEntity if iterable?
     end
@@ -125,11 +123,7 @@ module BooticClient
           end
           if rel != CURIES_REL
             rel_attrs['name'] = rel
-            memo[rel.to_sym] = Relation.new(
-              rel_attrs,
-              client,
-              complain_on_undeclared_params: config.complain_on_undeclared_params
-            )
+            memo[rel.to_sym] = Relation.new(rel_attrs, client)
           end
         end
       )
@@ -137,7 +131,7 @@ module BooticClient
 
     protected
 
-    attr_reader :client, :top, :attrs, :config
+    attr_reader :client, :top, :attrs
 
     def iterable?
       has_entity?(:items) && entities[:items].respond_to?(:each)

--- a/lib/bootic_client/relation.rb
+++ b/lib/bootic_client/relation.rb
@@ -9,8 +9,8 @@ module BooticClient
     HEAD = 'head'.freeze
     OPTIONS = 'options'.freeze
 
-    def initialize(attrs, client, wrapper_class = Entity, complain_on_undeclared_params: true)
-      @attrs, @client, @wrapper_class = attrs, client, wrapper_class
+    def initialize(attrs, client, entity_class: Entity, complain_on_undeclared_params: true)
+      @attrs, @client, @entity_class = attrs, client, entity_class
       @complain_on_undeclared_params = complain_on_undeclared_params
     end
 
@@ -62,9 +62,9 @@ module BooticClient
         end
         # remove payload vars from URI opts if destructive action
         opts = opts.reject{|k, v| !uri_vars.include?(k.to_s) } if destructive?
-        client.request_and_wrap transport_method.to_sym, uri.expand(opts), wrapper_class, payload
+        client.request_and_wrap transport_method.to_sym, uri.expand(opts), entity_class, payload
       else
-        client.request_and_wrap transport_method.to_sym, href, wrapper_class, opts
+        client.request_and_wrap transport_method.to_sym, href, entity_class, opts
       end
     end
 
@@ -73,7 +73,7 @@ module BooticClient
     end
 
     protected
-    attr_reader :wrapper_class, :client, :attrs, :complain_on_undeclared_params
+    attr_reader :entity_class, :client, :attrs, :complain_on_undeclared_params
 
     def uri
       @uri ||= WhinyURI.new(href, complain_on_undeclared_params)

--- a/lib/bootic_client/relation.rb
+++ b/lib/bootic_client/relation.rb
@@ -1,15 +1,24 @@
 require "bootic_client/whiny_uri"
 require "bootic_client/entity"
+require 'ostruct'
 
 module BooticClient
 
   class Relation
-
     GET = 'get'.freeze
     HEAD = 'head'.freeze
     OPTIONS = 'options'.freeze
 
-    def initialize(attrs, client, entity_class: Entity, complain_on_undeclared_params: true)
+    class << self
+      attr_writer :complain_on_undeclared_params
+
+      def complain_on_undeclared_params
+        return true unless instance_variable_defined?('@complain_on_undeclared_params')
+        @complain_on_undeclared_params
+      end
+    end
+
+    def initialize(attrs, client, entity_class: Entity, complain_on_undeclared_params: self.class.complain_on_undeclared_params)
       @attrs, @client, @entity_class = attrs, client, entity_class
       @complain_on_undeclared_params = complain_on_undeclared_params
     end

--- a/lib/bootic_client/relation.rb
+++ b/lib/bootic_client/relation.rb
@@ -9,8 +9,9 @@ module BooticClient
     HEAD = 'head'.freeze
     OPTIONS = 'options'.freeze
 
-    def initialize(attrs, client, wrapper_class = Entity)
+    def initialize(attrs, client, wrapper_class = Entity, complain_on_undeclared_params: true)
       @attrs, @client, @wrapper_class = attrs, client, wrapper_class
+      @complain_on_undeclared_params = complain_on_undeclared_params
     end
 
     def inspect
@@ -72,10 +73,10 @@ module BooticClient
     end
 
     protected
-    attr_reader :wrapper_class, :client, :attrs
+    attr_reader :wrapper_class, :client, :attrs, :complain_on_undeclared_params
 
     def uri
-      @uri ||= WhinyURI.new(href)
+      @uri ||= WhinyURI.new(href, complain_on_undeclared_params)
     end
 
     def destructive?

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -180,16 +180,6 @@ describe BooticClient::Entity do
             entity.search(foo: 'bar')
           }.to raise_error(BooticClient::InvalidURLError)
         end
-
-        it 'does not complain if passing configuration to Relation' do
-          config = double(complain_on_undeclared_params: false)
-          entity = BooticClient::Entity.new(list_payload, client, config: config)
-
-          expect(client).to receive(:request_and_wrap).with(:get, '/search?q=foo', BooticClient::Entity, {}).and_return next_page
-          entity.search(q: 'foo').tap do |next_entity|
-            expect(next_entity.page).to eql(2)
-          end
-        end
       end
 
     end

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -174,6 +174,22 @@ describe BooticClient::Entity do
             expect(next_entity.page).to eql(2)
           end
         end
+
+        it 'complains if passing undeclared link params' do
+          expect {
+            entity.search(foo: 'bar')
+          }.to raise_error(BooticClient::InvalidURLError)
+        end
+
+        it 'does not complain if passing configuration to Relation' do
+          config = double(complain_on_undeclared_params: false)
+          entity = BooticClient::Entity.new(list_payload, client, config: config)
+
+          expect(client).to receive(:request_and_wrap).with(:get, '/search?q=foo', BooticClient::Entity, {}).and_return next_page
+          entity.search(q: 'foo').tap do |next_entity|
+            expect(next_entity.page).to eql(2)
+          end
+        end
       end
 
     end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -80,6 +80,25 @@ describe BooticClient::Relation do
           }.to raise_error BooticClient::InvalidURLError
         end
       end
+
+      context "configured to not complain on undeclared variables" do
+        let(:relation) {
+          BooticClient::Relation.new({
+            'href' => '/foos/{id}{?q,page}',
+            'templated' => true
+            },
+            client,
+            BooticClient::Entity,
+            complain_on_undeclared_params: false
+          )
+        }
+
+        it "whitelists params but does not complain" do
+          expect(client).to receive(:request_and_wrap).with(:get, '/foos/2?q=test&page=3', BooticClient::Entity, {foo: 1}).and_return entity
+
+          relation.run(id: 2, q: 'test', page: 3, foo: 1)
+        end
+      end
     end
 
     describe 'POST' do

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -82,20 +82,21 @@ describe BooticClient::Relation do
       end
 
       context "configured to not complain on undeclared variables" do
-        let(:relation) {
-          BooticClient::Relation.new({
+        it "whitelists params but does not complain" do
+          BooticClient::Relation.complain_on_undeclared_params = false
+
+          relation = BooticClient::Relation.new({
             'href' => '/foos/{id}{?q,page}',
             'templated' => true
             },
             client,
-            complain_on_undeclared_params: false
           )
-        }
 
-        it "whitelists params but does not complain" do
           expect(client).to receive(:request_and_wrap).with(:get, '/foos/2?q=test&page=3', BooticClient::Entity, {foo: 1}).and_return entity
 
           relation.run(id: 2, q: 'test', page: 3, foo: 1)
+
+          BooticClient::Relation.complain_on_undeclared_params = true
         end
       end
     end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -88,7 +88,6 @@ describe BooticClient::Relation do
             'templated' => true
             },
             client,
-            BooticClient::Entity,
             complain_on_undeclared_params: false
           )
         }


### PR DESCRIPTION
## What

Add optional configuration so link calls _do not_ raise an exception if passed query string params that are not declared in a URI Template. But make sure to always only use declared params when expanding templated URIs.

## Example

Normal behaviour is to raise an exception:

```ruby
relation = BooticClient::Relation.new({
 'href' => '/search{?q,page}`
}, client)

# call with undeclared params
relation.run('q' => 'foo', 'nopenope' => 1) # raises an exception
```

The optional, class-level `Relation.complain_on_undeclared_params` setting allows passing undeclared params

```ruby
BooticClient::Relation.complain_on_undeclared_params = false
# no exception, but only "?q=foo" will be expanded into final URL
relation.run('q' => 'foo', 'nopenope' => 1)
```

## Why

The default behaviour (exception on undeclared params) is useful for catching typos and other user errors, but in other contexts it is useful to pass a Hash of params and let the client white-list valid params without complaining. ie. Rails apps:

```ruby
BooticClient::Relation.complain_on_undeclared_params = false

# orders_controller.rb
def index
  # pass entire Rails params hash, which includes query string params
  # but also other keys, which will just be ignored.
  @orders = client.root.shops.first.orders(params)
end
```