### PR TITLE
Add :user_agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ You first must create an OAuth2 Application in your Bootic dashboard. Then confi
 
 ```ruby
 BooticClient.configure do |c|
+  # these are required for OAuth2 strategies
   c.client_id = ENV['BOOTIC_CLIENT_ID']
   c.client_secret = ENV['BOOTIC_CLIENT_SECRET']
+  # these are optional
   c.logger = Logger.new(STDOUT)
   c.logging = true
   c.cache_store = Rails.cache
+  c.user_agent = "My App v1"
 end
 ```
 

--- a/lib/bootic_client.rb
+++ b/lib/bootic_client.rb
@@ -13,7 +13,7 @@ module BooticClient
 
   class << self
     attr_accessor :logging
-    attr_reader :client_id, :client_secret, :cache_store
+    attr_reader :client_id, :client_secret, :cache_store, :user_agent
 
     def strategies
       @strategies ||= {}
@@ -24,8 +24,13 @@ module BooticClient
       opts[:logging] = logging
       opts[:logger] = logger if logging
       opts[:cache_store] = cache_store if cache_store
+      opts[:user_agent] = user_agent if user_agent
       require "bootic_client/strategies/#{strategy_name}"
       strategies.fetch(strategy_name.to_sym).new self, opts, &on_new_token
+    end
+
+    def user_agent=(v)
+      set_non_nil :user_agent, v
     end
 
     def client_id=(v)

--- a/lib/bootic_client/client.rb
+++ b/lib/bootic_client/client.rb
@@ -18,6 +18,7 @@ module BooticClient
       @options = {
         logging: false,
         faraday_adapter: [:net_http_persistent],
+        user_agent: USER_AGENT
       }.merge(options.dup)
 
       @options[:cache_store] = @options[:cache_store] || Faraday::HttpCache::MemoryStore.new
@@ -76,7 +77,7 @@ module BooticClient
 
     def request_headers
       {
-        'User-Agent' => USER_AGENT,
+        'User-Agent' => options[:user_agent],
         'Accept' => JSON_MIME,
         'Content-Type' => JSON_MIME
       }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -110,6 +110,27 @@ describe BooticClient::Client do
 
       end
 
+      context 'User-Agent' do
+        it 'sends it' do
+          req = stub_request(:get, root_url)
+            .with(headers: {'User-Agent' => described_class::USER_AGENT})
+            .to_return(status: 200, body: JSON.dump(root_data), headers: response_headers)
+
+          client.get(root_url, {}, request_headers)
+          expect(req).to have_been_requested
+        end
+
+        it 'can be configured' do
+          client = described_class.new(user_agent: 'foobar')
+          req = stub_request(:get, root_url)
+            .with(headers: {'User-Agent' => 'foobar'})
+            .to_return(status: 200, body: JSON.dump(root_data), headers: response_headers)
+
+          client.get(root_url, {}, request_headers)
+          expect(req).to have_been_requested
+        end
+      end
+
       context 'errors' do
         describe '500 Server error' do
           before do


### PR DESCRIPTION
## What

Add `:user_agent` option to client initialization. Sent out with every request as the `User-Agent` header. Defaults to gem version, Ruby version and platform.

```ruby
BooticClient.configure do |c|
  c.user_agent = "MyApp"
end
```

Note that the user agent can also be passed on a per-instance basis.

```ruby
client = BooticClient.client(:authorized, user_agent: "MyApp", access_token: "zzz")
```

## Why
In some cases it makes sense to pass your own user agent, such as libraries that use this gem (ie. BooticCli)