### PR TITLE
Validate config setters

### DIFF
--- a/lib/bootic_client.rb
+++ b/lib/bootic_client.rb
@@ -5,7 +5,8 @@ require "bootic_client/relation"
 require "bootic_client/client"
 
 module BooticClient
-  NilConfigurationError = Class.new(StandardError)
+  InvalidConfigurationError = Class.new(StandardError)
+  VERY_BASIC_URL_CHECK = /^(http|https):/.freeze
 
   AUTH_HOST = 'https://auth.bootic.net'.freeze
   API_ROOT = 'https://api.bootic.net/v1'.freeze
@@ -40,10 +41,12 @@ module BooticClient
     end
 
     def auth_host=(v)
+      check_url! :auth_host, v
       set_non_nil :auth_host, v
     end
 
     def api_root=(v)
+      check_url! :api_root, v
       set_non_nil :api_root, v
     end
 
@@ -68,8 +71,12 @@ module BooticClient
     end
 
     def set_non_nil(name, v)
-      raise NilConfigurationError, "#{name} cannot be nil" if v.nil?
+      raise InvalidConfigurationError, "#{name} cannot be nil" if v.nil?
       instance_variable_set("@#{name}", v)
+    end
+
+    def check_url!(name, v)
+      raise InvalidConfigurationError, "#{name} must be a valid URL" unless v.to_s =~ VERY_BASIC_URL_CHECK
     end
   end
 end

--- a/lib/bootic_client.rb
+++ b/lib/bootic_client.rb
@@ -5,14 +5,14 @@ require "bootic_client/relation"
 require "bootic_client/client"
 
 module BooticClient
+  NilConfigurationError = Class.new(StandardError)
 
   AUTH_HOST = 'https://auth.bootic.net'.freeze
   API_ROOT = 'https://api.bootic.net/v1'.freeze
 
   class << self
-
-    attr_accessor :client_secret, :client_id, :logging, :cache_store
-    attr_writer :auth_host, :api_root, :logger
+    attr_accessor :logging
+    attr_reader :client_id, :client_secret, :cache_store
 
     def strategies
       @strategies ||= {}
@@ -25,6 +25,30 @@ module BooticClient
       opts[:cache_store] = cache_store if cache_store
       require "bootic_client/strategies/#{strategy_name}"
       strategies.fetch(strategy_name.to_sym).new self, opts, &on_new_token
+    end
+
+    def client_id=(v)
+      set_non_nil :client_id, v
+    end
+
+    def client_secret=(v)
+      set_non_nil :client_secret, v
+    end
+
+    def cache_store=(v)
+      set_non_nil :cache_store, v
+    end
+
+    def auth_host=(v)
+      set_non_nil :auth_host, v
+    end
+
+    def api_root=(v)
+      set_non_nil :api_root, v
+    end
+
+    def logger=(v)
+      set_non_nil :logger, v
     end
 
     def auth_host
@@ -42,6 +66,10 @@ module BooticClient
     def configure(&block)
       yield self
     end
-  end
 
+    def set_non_nil(name, v)
+      raise NilConfigurationError, "#{name} cannot be nil" if v.nil?
+      instance_variable_set("@#{name}", v)
+    end
+  end
 end

--- a/spec/client_credentials_strategy_spec.rb
+++ b/spec/client_credentials_strategy_spec.rb
@@ -15,7 +15,7 @@ describe 'BooticClient::Strategies::ClientCredentials' do
 
   describe 'with missing client credentials' do
     it 'raises error' do
-      BooticClient.client_id = nil
+      allow(BooticClient).to receive(:client_id).and_return nil
       expect{
         BooticClient.client(:client_credentials, scope: 'admin')
       }.to raise_error(ArgumentError)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -6,7 +6,7 @@ describe BooticClient do
       BooticClient.configure do |c|
         c.client_id = nil
       end
-    }.to raise_error BooticClient::NilConfigurationError
+    }.to raise_error BooticClient::InvalidConfigurationError
   end
 
   it "raises if nil client_secret" do
@@ -14,7 +14,7 @@ describe BooticClient do
       BooticClient.configure do |c|
         c.client_secret = nil
       end
-    }.to raise_error BooticClient::NilConfigurationError
+    }.to raise_error BooticClient::InvalidConfigurationError
   end
 
   it "raises if nil cache_store" do
@@ -22,23 +22,35 @@ describe BooticClient do
       BooticClient.configure do |c|
         c.cache_store = nil
       end
-    }.to raise_error BooticClient::NilConfigurationError
+    }.to raise_error BooticClient::InvalidConfigurationError
   end
 
-  it "raises if nil auth_host" do
+  it "raises if nil or invalid auth_host" do
     expect {
       BooticClient.configure do |c|
         c.auth_host = nil
       end
-    }.to raise_error BooticClient::NilConfigurationError
+    }.to raise_error BooticClient::InvalidConfigurationError
+
+    expect {
+      BooticClient.configure do |c|
+        c.auth_host = 'not-a-url'
+      end
+    }.to raise_error BooticClient::InvalidConfigurationError
   end
 
-  it "raises if nil api_root" do
+  it "raises if nil or invalid api_root" do
     expect {
       BooticClient.configure do |c|
         c.api_root = nil
       end
-    }.to raise_error BooticClient::NilConfigurationError
+    }.to raise_error BooticClient::InvalidConfigurationError
+
+    expect {
+      BooticClient.configure do |c|
+        c.api_root = 'not-a-url'
+      end
+    }.to raise_error BooticClient::InvalidConfigurationError
   end
 
   it "raises if nil logger" do
@@ -46,6 +58,6 @@ describe BooticClient do
       BooticClient.configure do |c|
         c.logger = nil
       end
-    }.to raise_error BooticClient::NilConfigurationError
+    }.to raise_error BooticClient::InvalidConfigurationError
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe BooticClient do
+  it "raises if nil client_id" do
+    expect {
+      BooticClient.configure do |c|
+        c.client_id = nil
+      end
+    }.to raise_error BooticClient::NilConfigurationError
+  end
+
+  it "raises if nil client_secret" do
+    expect {
+      BooticClient.configure do |c|
+        c.client_secret = nil
+      end
+    }.to raise_error BooticClient::NilConfigurationError
+  end
+
+  it "raises if nil cache_store" do
+    expect {
+      BooticClient.configure do |c|
+        c.cache_store = nil
+      end
+    }.to raise_error BooticClient::NilConfigurationError
+  end
+
+  it "raises if nil auth_host" do
+    expect {
+      BooticClient.configure do |c|
+        c.auth_host = nil
+      end
+    }.to raise_error BooticClient::NilConfigurationError
+  end
+
+  it "raises if nil api_root" do
+    expect {
+      BooticClient.configure do |c|
+        c.api_root = nil
+      end
+    }.to raise_error BooticClient::NilConfigurationError
+  end
+
+  it "raises if nil logger" do
+    expect {
+      BooticClient.configure do |c|
+        c.logger = nil
+      end
+    }.to raise_error BooticClient::NilConfigurationError
+  end
+end


### PR DESCRIPTION
## What

Raise known exception if attempting to configure client with `nil` values

```ruby
# Raises BooticClient::InvalidConfigurationError

BooticClient.configure do |c|
 c.client_id = nil # ex. ENV['MISSING_KEY']
end
```