### PR TITLE
Make configuration an instance

### DIFF
--- a/lib/bootic_client.rb
+++ b/lib/bootic_client.rb
@@ -3,85 +3,30 @@ require "bootic_client/version"
 require "bootic_client/entity"
 require "bootic_client/relation"
 require "bootic_client/client"
+require "bootic_client/configuration"
 
 module BooticClient
-  InvalidConfigurationError = Class.new(StandardError)
-  VERY_BASIC_URL_CHECK = /^(http|https):/.freeze
-
-  AUTH_HOST = 'https://auth.bootic.net'.freeze
-  API_ROOT = 'https://api.bootic.net/v1'.freeze
-
   class << self
-    attr_accessor :logging
-    attr_reader :client_id, :client_secret, :cache_store, :user_agent
-
     def strategies
       @strategies ||= {}
     end
 
     def client(strategy_name, client_opts = {}, &on_new_token)
       opts = client_opts.dup
-      opts[:logging] = logging
-      opts[:logger] = logger if logging
-      opts[:cache_store] = cache_store if cache_store
-      opts[:user_agent] = user_agent if user_agent
+      opts[:logging] = configuration.logging
+      opts[:logger] = configuration.logger if configuration.logging
+      opts[:cache_store] = configuration.cache_store if configuration.cache_store
+      opts[:user_agent] = configuration.user_agent if configuration.user_agent
       require "bootic_client/strategies/#{strategy_name}"
-      strategies.fetch(strategy_name.to_sym).new self, opts, &on_new_token
-    end
-
-    def user_agent=(v)
-      set_non_nil :user_agent, v
-    end
-
-    def client_id=(v)
-      set_non_nil :client_id, v
-    end
-
-    def client_secret=(v)
-      set_non_nil :client_secret, v
-    end
-
-    def cache_store=(v)
-      set_non_nil :cache_store, v
-    end
-
-    def auth_host=(v)
-      check_url! :auth_host, v
-      set_non_nil :auth_host, v
-    end
-
-    def api_root=(v)
-      check_url! :api_root, v
-      set_non_nil :api_root, v
-    end
-
-    def logger=(v)
-      set_non_nil :logger, v
-    end
-
-    def auth_host
-      @auth_host || AUTH_HOST
-    end
-
-    def api_root
-      @api_root || API_ROOT
-    end
-
-    def logger
-      @logger || ::Logger.new(STDOUT)
+      strategies.fetch(strategy_name.to_sym).new configuration, opts, &on_new_token
     end
 
     def configure(&block)
-      yield self
+      yield configuration
     end
 
-    def set_non_nil(name, v)
-      raise InvalidConfigurationError, "#{name} cannot be nil" if v.nil?
-      instance_variable_set("@#{name}", v)
-    end
-
-    def check_url!(name, v)
-      raise InvalidConfigurationError, "#{name} must be a valid URL" unless v.to_s =~ VERY_BASIC_URL_CHECK
+    def configuration
+      @configuration ||= Configuration.new
     end
   end
 end

--- a/lib/bootic_client/configuration.rb
+++ b/lib/bootic_client/configuration.rb
@@ -1,0 +1,65 @@
+module BooticClient
+  InvalidConfigurationError = Class.new(StandardError)
+  VERY_BASIC_URL_CHECK = /^(http|https):/.freeze
+
+  AUTH_HOST = 'https://auth.bootic.net'.freeze
+  API_ROOT = 'https://api.bootic.net/v1'.freeze
+
+  class Configuration
+    attr_accessor :logging
+    attr_reader :client_id, :client_secret, :cache_store, :user_agent
+
+    def user_agent=(v)
+      set_non_nil :user_agent, v
+    end
+
+    def client_id=(v)
+      set_non_nil :client_id, v
+    end
+
+    def client_secret=(v)
+      set_non_nil :client_secret, v
+    end
+
+    def cache_store=(v)
+      set_non_nil :cache_store, v
+    end
+
+    def auth_host=(v)
+      check_url! :auth_host, v
+      set_non_nil :auth_host, v
+    end
+
+    def api_root=(v)
+      check_url! :api_root, v
+      set_non_nil :api_root, v
+    end
+
+    def logger=(v)
+      set_non_nil :logger, v
+    end
+
+    def auth_host
+      @auth_host || AUTH_HOST
+    end
+
+    def api_root
+      @api_root || API_ROOT
+    end
+
+    def logger
+      @logger || ::Logger.new(STDOUT)
+    end
+
+    private
+
+    def set_non_nil(name, v)
+      raise InvalidConfigurationError, "#{name} cannot be nil" if v.nil?
+      instance_variable_set("@#{name}", v)
+    end
+
+    def check_url!(name, v)
+      raise InvalidConfigurationError, "#{name} must be a valid URL" unless v.to_s =~ VERY_BASIC_URL_CHECK
+    end
+  end
+end

--- a/lib/bootic_client/strategies/authorized.rb
+++ b/lib/bootic_client/strategies/authorized.rb
@@ -4,10 +4,11 @@ module BooticClient
   module Strategies
 
     class Authorized < Oauth2Strategy
-      protected
+      private
 
       def validate!
-        raise ArgumentError, "options MUST include access_token" unless options[:access_token]
+        raise ArgumentError, 'options MUST include access_token' unless options[:access_token]
+        raise ArgumentError, 'must include a Configuration object' unless config
       end
 
       def get_token

--- a/lib/bootic_client/strategies/basic_auth.rb
+++ b/lib/bootic_client/strategies/basic_auth.rb
@@ -8,11 +8,11 @@ module BooticClient
         %(#<#{self.class.name} root: #{config.api_root} username: #{options[:username]}>)
       end
 
-      protected
+      private
 
       def validate!
-        raise ArgumentError, "options MUST include username" unless options[:username]
-        raise ArgumentError, "options MUST include password" unless options[:password]
+        raise ArgumentError, 'options MUST include username' unless options[:username]
+        raise ArgumentError, 'options MUST include password' unless options[:password]
       end
 
       def client

--- a/lib/bootic_client/strategies/bearer.rb
+++ b/lib/bootic_client/strategies/bearer.rb
@@ -7,7 +7,7 @@ module BooticClient
       private
 
       def validate!
-        raise ArgumentError, "options MUST include access_token" unless options[:access_token]
+        raise ArgumentError, 'options MUST include access_token' unless options[:access_token]
       end
 
       def request_headers

--- a/lib/bootic_client/strategies/client_credentials.rb
+++ b/lib/bootic_client/strategies/client_credentials.rb
@@ -4,7 +4,7 @@ module BooticClient
   module Strategies
 
     class ClientCredentials < Oauth2Strategy
-      protected
+      private
 
       def get_token
         opts = {}

--- a/lib/bootic_client/strategies/oauth2_strategy.rb
+++ b/lib/bootic_client/strategies/oauth2_strategy.rb
@@ -10,12 +10,13 @@ module BooticClient
         %(#<#{self.class.name} cid: #{config.client_id} root: #{config.api_root} auth: #{config.auth_host}>)
       end
 
-      protected
+      private
 
       def validate!
-        raise ArgumentError, "MUST include client_id" unless config.client_id
-        raise ArgumentError, "MUST include client_secret" unless config.client_secret
-        raise ArgumentError, "MUST include api_root" unless config.api_root
+        raise ArgumentError, 'must include a Configuration object' unless config
+        raise ArgumentError, 'MUST include client_id' unless config.client_id
+        raise ArgumentError, 'MUST include client_secret' unless config.client_secret
+        raise ArgumentError, 'MUST include api_root' unless config.api_root
       end
 
       def pre_flight

--- a/spec/client_credentials_strategy_spec.rb
+++ b/spec/client_credentials_strategy_spec.rb
@@ -15,7 +15,7 @@ describe 'BooticClient::Strategies::ClientCredentials' do
 
   describe 'with missing client credentials' do
     it 'raises error' do
-      allow(BooticClient).to receive(:client_id).and_return nil
+      allow(BooticClient.configuration).to receive(:client_id).and_return nil
       expect{
         BooticClient.client(:client_credentials, scope: 'admin')
       }.to raise_error(ArgumentError)


### PR DESCRIPTION
So different clients can be initialized with different configuration.

`BooticClient.configure { |c| .. }` uses a singleton instance of `BooticClient::Configuration`, but other instances can be created for custom clients.

```ruby
config = BooticClient::Configuration.new
config.client_id = 'abc'
config.client_secret = 'xxx'

client = BooticClient::Strategies::Authorized.new(config, access_token: 'zzz')
```