### PR TITLE
Wrap all hash properties in Entity.new, even if not in _embedded group.

### DIFF
--- a/lib/bootic_client/entity.rb
+++ b/lib/bootic_client/entity.rb
@@ -1,5 +1,4 @@
 require "bootic_client/relation"
-require 'ostruct'
 
 module BooticClient
   module EnumerableEntity
@@ -60,7 +59,7 @@ module BooticClient
 
     def properties
       @properties ||= attrs.select{|k,v| !(k =~ SPECIAL_PROP_EXP)}.each_with_object({}) do |(k,v),memo|
-        memo[k.to_sym] = Entity.wrap(v)
+        memo[k.to_sym] = Entity.wrap(v, client: client, top: top)
       end
     end
 
@@ -68,10 +67,10 @@ module BooticClient
       @links ||= attrs.fetch('_links', {})
     end
 
-    def self.wrap(obj)
+    def self.wrap(obj, client: nil, top: nil)
       case obj
       when Hash
-        OpenStruct.new(obj)
+        new(obj, client, top: top)
       when Array
         obj.map{|e| wrap(e)}
       else
@@ -129,7 +128,7 @@ module BooticClient
       )
     end
 
-    protected
+    private
 
     attr_reader :client, :top, :attrs
 

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -9,7 +9,8 @@ describe BooticClient::Entity do
       'page' => 1,
       'an_object' => {
         'name' => 'Foobar',
-        'age' => 22
+        'age' => 22,
+        'another_object' => {'foo' => 'bar'}
       },
       '_links' => {
         'self' => {'href' => '/foo'},
@@ -74,8 +75,11 @@ describe BooticClient::Entity do
     end
 
     it 'wraps object properties as entities' do
+      expect(entity.an_object).to be_a described_class
       expect(entity.an_object.name).to eql('Foobar')
       expect(entity.an_object.age).to eql(22)
+      expect(entity.an_object.another_object).to be_a described_class
+      expect(entity.an_object.another_object.foo).to eq 'bar'
     end
 
     it 'has a #properties object' do


### PR DESCRIPTION
## What

Wrap all Hash properties in `Entity.new`, even if they're not in the `_embedded` group. It was using `OpenStruct` before this.

```ruby
data = {
  'name' => 'Foo',
  'friend' => {
    'name' => 'Bar',
    'a_hash' => {'one' => 1}
  },
  '_embedded' => {
    'account' => {'id' => 1}
  }
}

entity = BooticClient::Entity.new(data, client)
entity.friend # intance of BooticClient::Entity
entity.account # instance of BooticClient::Entity
```

## Why

Make this library more useful to wrap non-HAL compliant APIs.
Provides better inspection on any sub-entity and `#to_hash`.

## Notes on backwards-compatibility

This could cause backwards-incompatible issues if client code was checking for `OpenStruct` instances specifically, or assuming `nil` values from non-existing keys.

```
# before, using OpenStruct
entity.friend.does_not_exist # nil

# after, using Entity
entity.friend.does_not_exist # NoMethodError: undefined method `does_not_exist`
```

`Entity` wraps properties recursively.

```ruby
# Before
entity.friend.a_hash # {'one' => 1}

# After
entity.friend.a_hash # instance of BooticClient::Entity
entity.friend.a_hash.one # 1
```
