### PR TITLE
Update gems, fix HTTP cache

### DIFF
--- a/bootic_client.gemspec
+++ b/bootic_client.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", '~> 0.9'
+  spec.add_dependency "faraday", '~> 0.15'
   spec.add_dependency "uri_template", '~> 0.7'
-  spec.add_dependency "faraday_middleware", '~> 0.9'
-  spec.add_dependency "faraday-http-cache", '1.2.2'
+  spec.add_dependency "faraday_middleware", '~> 0.13'
+  spec.add_dependency "faraday-http-cache", '~> 2'
   spec.add_dependency "net-http-persistent", '~> 2.9'
-  spec.add_dependency "oauth2", "1.3.1"
+  spec.add_dependency "oauth2", "~> 1.4"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/bootic_client.gemspec
+++ b/bootic_client.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", '~> 0.15'
   spec.add_dependency "uri_template", '~> 0.7'
-  spec.add_dependency "faraday_middleware", '~> 0.13'
   spec.add_dependency "faraday-http-cache", '~> 2'
   spec.add_dependency "net-http-persistent", '~> 2.9'
   spec.add_dependency "oauth2", "~> 1.4"

--- a/lib/bootic_client/client.rb
+++ b/lib/bootic_client/client.rb
@@ -1,6 +1,5 @@
 require 'base64'
 require 'faraday'
-require 'faraday_middleware'
 require 'faraday-http-cache'
 require "bootic_client/errors"
 require 'faraday/adapter/net_http_persistent'

--- a/lib/bootic_client/client.rb
+++ b/lib/bootic_client/client.rb
@@ -60,14 +60,25 @@ module BooticClient
       end
     end
 
+    class UTF8JSON
+      def self.dump(data)
+        data[:body] = data[:body].force_encoding('UTF-8') if data[:body].is_a?(String)
+        JSON.dump(data)
+      end
+
+      def self.load(string)
+        JSON.load(string)
+      end
+    end
+
     private
 
     def conn(&block)
       @conn ||= Faraday.new do |f|
-        cache_options = {serializer: Marshal, shared_cache: false, store: options[:cache_store]}
+        cache_options = {serializer: UTF8JSON, shared_cache: false, store: options[:cache_store]}
         cache_options[:logger] = options[:logger] if options[:logging]
 
-        # f.use :http_cache, cache_options
+        f.use :http_cache, cache_options
         f.response :logger, options[:logger] if options[:logging]
         yield f if block_given?
         f.adapter *Array(options[:faraday_adapter])


### PR DESCRIPTION
## What

* Update Faraday and Oauth2 gems.
* Remove Faraday Middleware gem (we're parsing JSON ourselves now)
* Fix HTTP caching middleware (it breaks when response data isn't UTF-8. This issue surfaced when I removed JSON middleware).

## Notes

Apps that use this gem might have to update their versions of Oauth2 if they use it. Ie. https://github.com/bootic/omniauth-bootic
