### PR TITLE
Make HTTP cache serialize binary data (ex. images) safely

### DIFF
--- a/spec/safe_cache_serializer_spec.rb
+++ b/spec/safe_cache_serializer_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe BooticClient::Client::SafeCacheSerializer do
+  context 'deserializing existing non-base64 content' do
+    it 'does not attempt Base64 decoding' do
+      result = described_class.load('{"headers": {"foo": 1}, "body": "hello"}')
+      expect(result['body']).to eq 'hello'
+    end
+  end
+
+  context 'Base64-encoding and decoding' do
+    it 'decodes body if flagged as Base64' do
+      body = Base64.strict_encode64('hello')
+      encoded = %({"headers": {"foo": 1}, "body": "__booticclient__base64__:#{body}"})
+      result = described_class.load(encoded)
+      expect(result['body']).to eq 'hello'
+    end
+
+    it 'encodes as Base64 with flag prefix' do
+      data = Base64.strict_encode64('{"headers": {"foo": 1}, "body": "hello"}')
+      encoded = described_class.dump({headers: {foo: 1}, body: 'hello'})
+      parsed = JSON.load(encoded)
+      expect(parsed['body']).to eq "__booticclient__base64__:#{Base64.strict_encode64('hello')}"
+    end
+
+    it 'encodes and decodes' do
+      encoded = described_class.dump({headers: {foo: 1}, body: 'hello'})
+      decoded = described_class.load(encoded)
+      expect(decoded['body']).to eq 'hello'
+    end
+  end
+end


### PR DESCRIPTION
## What

Allow HTTP Cache middleware to safely serialize binary responses (ex. images).

## Why

So we can treat product images (and any other binary resource) as _io_ objects, as introduced [in this PR](https://github.com/bootic/bootic_client.rb/pull/18)

```ruby
image = product.images.first.thumbnail # wraps image data in IO-like object
File.open(image.file_name, 'wb') do |f|
  f.write image.read
end
```

This was working before without a caching store, but failing in other stores when trying to JSON-encode binary image data.

## How

* Pass our own serializer class to the Faraday-HTTP-Cache middleware. 
* Custom serializer will make sure to Base64-encode response body data before saving in storage, and Base64-decode it when deserializing cached responses.
* It also adds a `__booticclient_base64_:` prefix to cached data. If previously cached data doesn't include that, it will not be Base64-decoded (so that it's backwards-compatible with data cached before this change)

