### PR TITLE
Update faraday fix for ruby 3

### DIFF
--- a/bootic_client.gemspec
+++ b/bootic_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", '~> 0.15'
+  spec.add_dependency "faraday", '>= 0.15'
   spec.add_dependency "uri_template", '~> 0.7'
   spec.add_dependency "faraday-http-cache", '~> 2'
   spec.add_dependency "net-http-persistent", '~> 3.0'

--- a/bootic_client.gemspec
+++ b/bootic_client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", '>= 0.15'
   spec.add_dependency "uri_template", '~> 0.7'
   spec.add_dependency "faraday-http-cache", '~> 2'
-  spec.add_dependency "net-http-persistent", '~> 3.0'
+  spec.add_dependency "net-http-persistent", '~> 4'
   spec.add_dependency "oauth2", "~> 1.4"
 
   spec.add_development_dependency "rake"

--- a/lib/bootic_client/client.rb
+++ b/lib/bootic_client/client.rb
@@ -86,7 +86,7 @@ module BooticClient
         cache_options = {serializer: SafeCacheSerializer, shared_cache: false, store: options[:cache_store]}
         cache_options[:logger] = options[:logger] if options[:logging]
 
-        f.use :http_cache, cache_options
+        f.use :http_cache, **cache_options
         f.response :logger, options[:logger] if options[:logging]
         yield f if block_given?
         f.adapter *Array(options[:faraday_adapter])

--- a/spec/authorized_strategy_spec.rb
+++ b/spec/authorized_strategy_spec.rb
@@ -23,7 +23,7 @@ describe 'BooticClient::Strategies::Authorized' do
       to_return(status: status, :headers => response_headers, :body => JSON.dump(body))
   end
 
-  def stub_auth(expired_token, status, body, client_id: '', client_secret: '', scope: '')
+  def stub_auth(expired_token, status, body = {})
     now = Time.now
     allow(Time).to receive(:now).and_return now
 
@@ -31,10 +31,10 @@ describe 'BooticClient::Strategies::Authorized' do
       with(body: {
         "assertion" => jwt_assertion(expired_token, now),
         "assertion_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer",
-        "client_id" => client_id,
-        "client_secret" => client_secret,
+        "client_id" => '',
+        "client_secret" => '',
         "grant_type" => "assertion",
-        "scope"=>scope
+        "scope" => ''
       },
       headers: {
         'Content-Type'=>'application/x-www-form-urlencoded'
@@ -114,6 +114,7 @@ describe 'BooticClient::Strategies::Authorized' do
         root = client.root
         expect(@failed_root_request).to have_been_requested
         expect(@auth_request).to have_been_requested
+        expect(@successful_root_request).to have_been_requested
         expect(root.message).to eql('Hello!')
       end
 

--- a/spec/authorized_strategy_spec.rb
+++ b/spec/authorized_strategy_spec.rb
@@ -31,7 +31,7 @@ describe 'BooticClient::Strategies::Authorized' do
       with(body: {
         "assertion" => jwt_assertion(expired_token, now),
         "assertion_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer",
-        "client_id" => '',
+        "client_id" => '', # JWT assertion flow does not need client_id or secret, but library sends them empty
         "client_secret" => '',
         "grant_type" => "assertion",
         "scope" => ''


### PR DESCRIPTION
Includes https://github.com/bootic/bootic_client.rb/pull/22

Update dependencies and syntax to work on Ruby 3.

* Update faraday to >= 0.15
* Update net-http-persistent to ~> 4
* Fix syntax for keyword args
* Fix test helper, make it work on Ruby 3