### PR TITLE
Update Faraday to ~> 2.0

### DIFF
--- a/bootic_client.gemspec
+++ b/bootic_client.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", '>= 0.15'
+  spec.add_dependency "faraday", '~> 2.2'
+  spec.add_dependency 'faraday-net_http_persistent', '~> 2.0'
   spec.add_dependency "uri_template", '~> 0.7'
   spec.add_dependency "faraday-http-cache", '~> 2'
   spec.add_dependency "net-http-persistent", '~> 4'

--- a/lib/bootic_client/client.rb
+++ b/lib/bootic_client/client.rb
@@ -4,7 +4,7 @@ require 'base64'
 require 'faraday'
 require 'faraday-http-cache'
 require "bootic_client/errors"
-require 'faraday/adapter/net_http_persistent'
+require 'faraday/net_http_persistent'
 
 module BooticClient
 

--- a/lib/bootic_client/strategies/basic_auth.rb
+++ b/lib/bootic_client/strategies/basic_auth.rb
@@ -19,7 +19,7 @@ module BooticClient
 
       def client
         @client ||= Client.new(options) do |c|
-          c.request :basic_auth, options[:username], options[:password]
+          c.request :authorization, :basic, options[:username], options[:password]
         end
       end
     end


### PR DESCRIPTION
Pin Faraday version to ~> 2.0 and require faraday-net_http_persistentent dependency.

The issue: https://github.com/bootic/bootic_client.rb/issues/24